### PR TITLE
Updated for Minecraft 1.9

### DIFF
--- a/src/main/java/io/playpen/plugin/mcbalancer/ServerListPing.java
+++ b/src/main/java/io/playpen/plugin/mcbalancer/ServerListPing.java
@@ -158,7 +158,6 @@ public class ServerListPing {
 
     @Data
     public static class StatusResponse {
-        private String description;
         private Players players;
         private Version version;
         private String favicon;


### PR DESCRIPTION
1.9 uses JSON components and MCBalancer doesn't care about the server MOTD, so don't deserialize it.

@redxdev I think you forgot to add me to the plugin repos.
